### PR TITLE
add plt.gcf().canvas.draw() to force rendering

### DIFF
--- a/pystrat/pystrat.py
+++ b/pystrat/pystrat.py
@@ -733,6 +733,7 @@ class Section:
                     cur_text = ax.text(cur_x_text, cur_y_text, name, 
                             va='center_baseline', ha='center', rotation_mode='anchor',
                             rotation=90, fontsize=unit_fontsize)
+                    plt.gcf().canvas.draw()
                     # get resulting data coordinates of the plotted label
                     transf = ax.transData.inverted()
                     bb = cur_text.get_window_extent()


### PR DESCRIPTION
This commit addresses the bug raised in issue #13 by adding `plt.gcf().canvas.draw()` prior to bb = cur_text.get_window_extent(). It seems to fix the issue, but I want to make sure that there aren't unintended consequences elsewhere.  